### PR TITLE
Update the container during the build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 FROM tomcat:9-jdk11-temurin-focal
 
-RUN apt-get update -y
+RUN apt-get update \
+    && apt-get full-upgrade -y
 RUN apt-get install -y \
 	aapt \
 	wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM tomcat:9-jdk11-temurin-focal
 
 RUN apt-get update \
-    && apt-get full-upgrade -y
+    && apt-get upgrade -y
 RUN apt-get install -y \
 	aapt \
 	wget \


### PR DESCRIPTION
The -y for apt-get update is not necessary, and we should make sure that packages in the container is actually up to date.