### PR TITLE
Use aapt2 instead of 1

### DIFF
--- a/templates/conf/context_template.xml
+++ b/templates/conf/context_template.xml
@@ -38,7 +38,7 @@
 
     <Parameter name="log4j.config" value="file:///usr/local/tomcat/work/log4j-hmdm.xml"/>
 
-    <Parameter name="aapt.command" value="aapt"/>
+    <Parameter name="aapt.command" value="aapt2"/>
 
     <!-- MQTT notification service parameters -->
     <Parameter name="mqtt.server.uri" value="0.0.0.0:31000"/>


### PR DESCRIPTION
Ubuntu contains both aapt 1 and 2 with aapt, and using aapt2 seems fine in my environment