### PR TITLE
Addition of reverse proxy support to official container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# CHANGELOG
+
+All notable changes to the Headwind MDM Docker build will be documented in this file.
+
+## [Fork Published] - 2025-10-02
+
+**Objective:** Make the official container easier to operate behind a reverse proxy with minimal changes while preserving backward compatibility.
+
+### Added
+- `rproxy_server.xml` template in `templates/conf/` directory
+  - Modified version of `server.xml` that allows Tomcat to respect proxy headers
+- `REVERSE_PROXY` environment variable support (defaults to `false`)
+- `EFFECTIVE_PROTOCOL` internal variable to preserve original `PROTOCOL` variable
+
+### Changed
+- Modified `docker-entrypoint.sh`:
+  - Added reverse proxy detection logic
+  - Updated server configuration selection based on `REVERSE_PROXY` setting
+  - Modified protocol handling in ROOT.xml creation and SQL replacement routines
+  - Bypass certbot initialization when operating behind reverse proxy
+
+### Technical Details
+- **Backward Compatibility:** Existing deployments continue to work without changes
+- **Default Behavior:** All changes are opt-in via the `REVERSE_PROXY=true` environment variable
+- **Configuration:** When enabled, replaces default `server.xml` with reverse proxy-aware version

--- a/REVERSE_PROXY.md
+++ b/REVERSE_PROXY.md
@@ -1,0 +1,510 @@
+# Reverse Proxy Configuration for Headwind MDM
+
+This document provides configuration examples for running Headwind MDM behind a reverse proxy. The reverse proxy functionality allows you to terminate SSL at the proxy level and simplifies deployment in modern containerized environments.
+
+## Overview
+
+When `REVERSE_PROXY=true` is set, Headwind MDM:
+- Uses a modified Tomcat configuration that respects proxy headers
+- Skips certbot initialization (SSL handled by proxy)
+- Properly handles protocol detection from proxy headers
+- Maintains full backward compatibility when disabled
+
+## Environment Variables
+
+| Variable | Proxy Setting | Description |
+|----------|---------|-------------|
+| `REVERSE_PROXY` | `true` | Enable reverse proxy mode |
+| `PROTOCOL` | `http` | Use http for MDM. TLS terminates at proxy |
+| `BASE_DOMAIN` | Required | Domain name for the service |
+
+***NOTE***
+All examples below are generic in nature and not intended to be used as is. 
+
+## Docker Compose Examples
+
+### Traefik Configuration
+
+#### Basic Traefik Setup
+
+```yaml
+version: '3.8'
+
+services:
+  traefik:
+    image: traefik:v3.0
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"  # Traefik dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./acme.json:/acme.json
+    networks:
+      - hmdm-network
+
+  hmdm:
+    image: headwindmdm/hmdm:0.1.5
+    environment:
+      - REVERSE_PROXY=true
+      - PROTOCOL=http
+      - BASE_DOMAIN=mdm.yourdomain.com
+      - SQL_HOST=postgres
+      - SQL_BASE=hmdm
+      - SQL_USER=hmdm
+      - SQL_PASS=topsecret
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hmdm.rule=Host(`mdm.yourdomain.com`)"
+      - "traefik.http.routers.hmdm.entrypoints=websecure"
+      - "traefik.http.routers.hmdm.tls=true"
+      - "traefik.http.routers.hmdm.tls.certresolver=letsencrypt"
+      - "traefik.http.services.hmdm.loadbalancer.server.port=8080"
+      # Device communication port
+      - "traefik.tcp.routers.hmdm-device.rule=HostSNI(`mdm.yourdomain.com`)"
+      - "traefik.tcp.routers.hmdm-device.entrypoints=device-port"
+      - "traefik.tcp.routers.hmdm-device.tls=true"
+      - "traefik.tcp.services.hmdm-device.loadbalancer.server.port=31000"
+    networks:
+      - hmdm-network
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=hmdm
+      - POSTGRES_USER=hmdm
+      - POSTGRES_PASSWORD=topsecret
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - hmdm-network
+
+networks:
+  hmdm-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+```
+
+#### Traefik Configuration File (traefik.yml)
+
+```yaml
+api:
+  dashboard: true
+  debug: true
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+
+  websecure:
+    address: ":443"
+
+  device-port:
+    address: ":31000"
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      tlsChallenge: {}
+      email: your-email@domain.com
+      storage: /acme.json
+      keyType: EC256
+```
+
+### Nginx Configuration
+
+#### Docker Compose with Nginx
+
+```yaml
+version: '3.8'
+
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+      - "31000:31000"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/ssl/certs:ro
+    depends_on:
+      - hmdm
+    networks:
+      - hmdm-network
+
+  hmdm:
+    image: headwindmdm/hmdm:0.1.5
+    environment:
+      - REVERSE_PROXY=true
+      - PROTOCOL=http
+      - BASE_DOMAIN=mdm.yourdomain.com
+      - SQL_HOST=postgres
+      - SQL_BASE=hmdm
+      - SQL_USER=hmdm
+      - SQL_PASS=topsecret
+    expose:
+      - "8080"
+      - "31000"
+    networks:
+      - hmdm-network
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=hmdm
+      - POSTGRES_USER=hmdm
+      - POSTGRES_PASSWORD=topsecret
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - hmdm-network
+
+networks:
+  hmdm-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+```
+
+#### Nginx Configuration File (nginx.conf)
+
+```nginx
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream hmdm_backend {
+        server hmdm:8080;
+    }
+
+    server {
+        listen 80;
+        server_name mdm.yourdomain.com;
+        return 301 https://$server_name$request_uri;
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name mdm.yourdomain.com;
+
+        ssl_certificate /etc/ssl/certs/cert.pem;
+        ssl_certificate_key /etc/ssl/certs/privkey.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+
+        client_max_body_size 100M;
+
+        location / {
+            proxy_pass http://hmdm_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+            
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # Timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+    }
+}
+
+# TCP stream for device communication port
+stream {
+    upstream hmdm_devices {
+        server hmdm:31000;
+    }
+
+    server {
+        listen 31000;
+        proxy_pass hmdm_devices;
+        proxy_timeout 1s;
+        proxy_responses 1;
+    }
+}
+```
+
+## Kubernetes Examples
+
+### Traefik on Kubernetes
+
+#### Deployment and Service
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hmdm
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hmdm
+  template:
+    metadata:
+      labels:
+        app: hmdm
+    spec:
+      containers:
+      - name: hmdm
+        image: headwindmdm/hmdm:0.1.5
+        env:
+        - name: REVERSE_PROXY
+          value: "true"
+        - name: PROTOCOL
+          value: "http"
+        - name: BASE_DOMAIN
+          value: "mdm.yourdomain.com"
+        - name: SQL_HOST
+          value: "postgres-service"
+        - name: SQL_BASE
+          value: "hmdm"
+        - name: SQL_USER
+          value: "hmdm"
+        - name: SQL_PASS
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: password
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 31000
+          name: device-port
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hmdm-service
+spec:
+  selector:
+    app: hmdm
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  - name: device-port
+    port: 31000
+    targetPort: 31000
+  type: ClusterIP
+```
+
+#### Traefik IngressRoute
+
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: hmdm-web
+  namespace: default
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host(`mdm.yourdomain.com`)
+    kind: Rule
+    services:
+    - name: hmdm-service
+      port: 8080
+  tls:
+    certResolver: letsencrypt
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: hmdm-device
+  namespace: default
+spec:
+  entryPoints:
+    - device-port
+  routes:
+  - match: HostSNI(`mdm.yourdomain.com`)
+    services:
+    - name: hmdm-service
+      port: 31000
+  tls:
+    passthrough: false
+    secretName: mdm-tls-cert
+```
+
+### Nginx Ingress on Kubernetes
+
+#### Ingress Configuration
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hmdm-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - hosts:
+    - mdm.yourdomain.com
+    secretName: hmdm-tls
+  rules:
+  - host: mdm.yourdomain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: hmdm-service
+            port:
+              number: 8080
+
+---
+# For device communication port, use a separate service
+apiVersion: v1
+kind: Service
+metadata:
+  name: hmdm-device-service
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "hmdm-shared"
+spec:
+  selector:
+    app: hmdm
+  ports:
+  - name: device-port
+    port: 31000
+    targetPort: 31000
+    protocol: TCP
+  type: LoadBalancer
+  loadBalancerIP: your-external-ip  # Optional: specify IP
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **502 Bad Gateway**
+   - Check if HMDM container is running: `docker ps`
+   - Verify network connectivity between proxy and HMDM
+   - Check HMDM logs: `docker logs <container-name>`
+
+2. **Redirect Loops**
+   - Ensure `REVERSE_PROXY=true` is set
+   - Verify proxy headers are being sent correctly
+   - Check that `PROTOCOL` matches your proxy configuration
+
+3. **Device Connection Issues**
+   - Ensure port 31000 is properly proxied
+   - For TCP proxying, verify stream configuration in nginx
+   - Check firewall rules for port 31000
+
+### Verification Steps
+
+1. **Check container status:**
+   ```bash
+   docker logs hmdm | grep "REVERSE_PROXY"
+   ```
+
+2. **Verify proxy headers:**
+   ```bash
+   curl -H "Host: mdm.yourdomain.com" \
+        -H "X-Forwarded-Proto: https" \
+        -H "X-Forwarded-For: 192.168.1.1" \
+        http://localhost:8080/
+   ```
+
+3. **Test device port:**
+   ```bash
+   telnet mdm.yourdomain.com 31000
+   ```
+
+## Security Considerations
+
+1. **Always use HTTPS** in production environments
+2. **Restrict access** to the Traefik/nginx admin interfaces
+3. **Keep certificates updated** using automated renewal
+4. **Monitor proxy logs** for suspicious activity
+5. **Use strong SSL/TLS configurations**
+
+## Performance Tuning
+
+### For High Load Environments
+
+1. **Increase worker connections** in nginx
+2. **Enable connection pooling** in reverse proxy
+3. **Configure appropriate timeouts** for long-running requests
+4. **Use HTTP/2** where supported
+5. **Consider load balancing** multiple HMDM instances
+
+### Resource Allocation
+
+```yaml
+# Kubernetes resource recommendations
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+```
+
+## Migration from Direct Deployment
+
+To migrate from a direct deployment to reverse proxy:
+
+1. **Update environment variables:**
+   ```bash
+   REVERSE_PROXY=true
+   # Keep existing PROTOCOL, BASE_DOMAIN, etc.
+   ```
+
+2. **Configure your reverse proxy** using the examples above
+
+3. **Update DNS** to point to your reverse proxy
+
+4. **Test thoroughly** before switching production traffic
+
+5. **Remove certbot** from the HMDM container (handled by proxy)
+
+The reverse proxy mode maintains full compatibility with existing configurations while providing the flexibility needed for modern deployment patterns.

--- a/templates/conf/rproxy_server.xml
+++ b/templates/conf/rproxy_server.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+		<Certificate certificateKeystoreFile="/usr/local/tomcat/ssl/hmdm.jks"
+			certificateKeystorePassword="123456"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector protocol="AJP/1.3"
+               address="::1"
+               port="8009"
+               redirectPort="8443" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>


### PR DESCRIPTION
# Summary
Add REVERSE_PROXY mode to run Headwind behind TLS-terminating reverse proxies (Traefik/Nginx).

## Behavior
	•	Default unchanged.
	•	When REVERSE_PROXY=true:
	•	Tomcat runs HTTP-only on 8080 with RemoteIpValve to honor X-Forwarded-Proto/Host/Port.
	•	External URLs in ROOT.xml/init SQL use https.
	•	Certbot/JKS block is skipped.

## Rationale
Many users terminate TLS at an ingress/proxy. Current startup fails if PROTOCOL=https (expects certbot files). This PR enables a supported path without breaking existing flows.

## Testing
	•	Verified default flows (PROTOCOL=http|https).
	•	Verified reverse-proxy flow with Traefik (HTTP→HTTPS redirect, TLS at proxy).
	•	QR JSON contains https://...; enrollment succeeds.
        •	Confirmed full functionality in Kubernetes cluster. Docker and Docker Swarm untested 


## Docs
	•	Added “REVERSE_PROXY.md” with compose and K8s examples.

## Compatibility
	•	No breaking changes. Env vars are backward compatible.
	•	POSIX sh compatible (no bashisms).